### PR TITLE
Fix plugin not working

### DIFF
--- a/example/apisix_conf/config.yaml
+++ b/example/apisix_conf/config.yaml
@@ -17,42 +17,16 @@
 
 apisix:
   node_listen: 9080              # APISIX listening port
-  enable_ipv6: false
   extra_lua_path: /opt/?.lua
-
-  enable_control: true
-  control:
-    ip: "0.0.0.0"
-    port: 9092
+  enable_admin: true
 
 deployment:
-  role: data_plane
-  role_data_plane:
-    config_provider: etcd
   admin:
     allow_admin:               # https://nginx.org/en/docs/http/ngx_http_access_module.html#allow
       - 0.0.0.0/0              # We need to restrict ip access rules for security. 0.0.0.0/0 is for test.
-
-    admin_key:
-      - name: "admin"
-        key: edd1c9f034335f136f87ad84b625c8f1
-        role: admin                 # admin: manage all configuration data
-
-      - name: "viewer"
-        key: 4054f7cf07e344346cd3f287985e76a2
-        role: viewer
-
   etcd:
     host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-      - "http://10.234.38.10:2379"          # multiple etcd address
-    prefix: "/apisix"               # apisix configurations prefix
-    timeout: 30                     # 30 seconds
-
-plugin_attr:
-  prometheus:
-    export_addr:
-      ip: "0.0.0.0"
-      port: 9091
+      - "http://etcd:2379"          # multiple etcd address
 
 plugins:                           # plugin list (sorted by priority)
   - real-ip                        # priority: 23000
@@ -148,14 +122,4 @@ plugins:                           # plugin list (sorted by priority)
   - serverless-post-function       # priority: -2000
   - ext-plugin-post-req            # priority: -3000
   - ext-plugin-post-resp           # priority: -4000
-  - 3rd-party                      # priority: 90
   - file-proxy                     # priority: 95
-
-stream_plugins:                    # stream plugin list (sorted by priority)
-  - ip-restriction                 # priority: 3000
-  - limit-conn                     # priority: 1003
-  - mqtt-proxy                     # priority: 1000
-  #- prometheus                    # priority: 500
-  - syslog                         # priority: 401
-  # <- recommend to use priority (0, 100) for your custom plugins
-        

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -23,22 +23,17 @@ services:
     restart: always
     volumes:
       - ./apisix_conf/config.yaml:/usr/local/apisix/conf/config.yaml:ro
-      - ./apisix_conf/config-default.yaml:/usr/local/apisix/conf/config-default.yaml:ro
       - ./apisix_conf/file-proxy.lua:/opt/apisix/plugins/file-proxy.lua:ro
-        #- ./apisix_conf/3rd-party.lua:/usr/local/apisix/apisix/plugins/3rd-party.lua
     
     #depends_on:
       #- etcd
     ##network_mode: host
     ports:
-      #      - "9180:9180/tcp"
-      - "9080:9080/tcp"
-      - "9091:9091/tcp"
-      - "9443:9443/tcp"
-      - "9092:9092/tcp"
-    networks:
-      apisix:
+      - "9180:9180"
+      - "9080:9080"
 
-networks:
-  apisix:
-    driver: bridge
+  etcd:
+    image: bitnami/etcd:3.5.13
+    environment:
+      ETCD_ENABLE_V2: true
+      ALLOW_NONE_AUTHENTICATION: yes


### PR DESCRIPTION
Create a route:

```bash
curl http://localhost:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
{
  "uri": "/anything",
  "upstream": {
    "nodes": {
      "httpbin.org:80": 1
    }
  },
  "plugins": {
    "file-proxy": {
      "path": "/tmp/hello.txt"
    }
  }
}'
```

Then test it:

```bash
curl localhost:9080/anything
```

It returns a 404 but something happens in the plugin with the log:

```
file-proxy.lua:49: phase_func(): ctx: {"conf_id":"1","route_id":"1","conf_version":16,"matched_route":"table: 0x1cab1bbc7e58","curr_req_matched":"table: 0x1cab1b66b2b8","plugins":"table: 0x1cab1b5ffbf0","var":{"_ctx":{"conf_id":"1","route_id":"1","conf_version":16,"matched_route":{"value":{"id":"1","update_time":1714059019,"priority":0,"status":1,"create_time":1714059019,"uri":"/anything","plugins":{"file-proxy":{"path":"/tmp/hello.txt"}},"upstream":{"scheme":"http","hash_on":"vars","nodes":[{"weight":1,"port":80,"host":"httpbin.org"}],"parent":{"value":{"upstream":{"scheme":"http","type":"roundrobin","hash_on":"vars","pass_host":"pass","nodes":[{"weight":1,"port":80,"host":"httpbin.org"}],"parent":"table: 0x1cab1b4c6f88"},"update_time":1714059019,"priority":0,"status":1,"create_time":1714059019,"uri":"/anything","plugins":{"file-proxy":{"path":"/tmp/hello.txt"}},"id":"1"},"clean_handlers":{},"orig_modifiedIndex":16,"key":"/apisix/routes/1","modifiedIndex":16,"createdIndex":16,"has_domain":true},"type":"roundrobin","pass_host":"pass"}},"clean_handlers":{},"orig_modifiedIndex":16,"key":"/apisix/routes/1","modifiedIndex":16,"createdIndex":16,"has_domain":true},"curr_req_matched":{"_method":"GET","_path":"/anything"},"plugins":[{"check_schema":"function: 0x1cab1b6b4248","name":"file-proxy","priority":1000,"version":1,"access":"function: 0x1cab1b6b3ff0","schema":{"$comment":"this is a mark for our injected plugin schema","properties":{"path":{"type":"string"},"_meta":{"type":"object","properties":{"disable":{"type":"boolean"},"filter":{"type":"array","description":"filter determines whether the plugin needs to be executed at runtime"},"error_response":{"oneOf":[{"type":"string"},{"type":"object"}]},"priority":{"type":"integer","description":"priority of plugins by customized order"}}}},"type":"object","required":["path"]},"log":"function: 0x1cab1b60dd40"},"table: 0x1cab1b4bddc0"],"var":"table: 0x1cab1bc94898","conf_type":"route","_plugin_name":"file-proxy","real_curr_req_matched_path":"/anything"},"_cache":{"scheme":"http","request_uri":"/anything","request_method":"GET","real_request_uri":"/anything","uri":"/anything","remote_addr":"192.168.65.1","host":"localhost"},"_request":"cdata<void *>: 0xaaaaf5eacc60"},"conf_type":"route","_plugin_name":"file-proxy","real_curr_req_matched_path":"/anything"} while logging request, client: 192.168.65.1, server: _, request: "GET /anything HTTP/1.1", host: "localhost:9080"
```
